### PR TITLE
Updated version number of intel docker image

### DIFF
--- a/Dockerfile.arc-xpu
+++ b/Dockerfile.arc-xpu
@@ -1,4 +1,4 @@
-FROM intel/intel-extension-for-pytorch:2.1.10-xpu 
+FROM intel/intel-extension-for-pytorch:2.5.10-xpu 
 ENV LANG=C.UTF-8
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Ran into some issues with the Dockerfile where apt update couldn't validate signature of Intel repo. Also, the container couldn't find my A750 video card. See #2 and #3.

Updating the version of the Intel docker image fixes both of these issues.